### PR TITLE
Allow naming tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ when it is time for breaks or to work again.
 - [ ] Show current interval type and name in standard output.
 - [ ] Show time passed for current interval in standard output.
 - [x] Show notifications when switching between work and breaks.
-- [ ] Allow interactive selection of tasks. The user should be able to enter
-      tasks one-by-one which will then be looped through.
+- [x] Allow interactive specification of tasks. The user should be able to enter
+      tasks one-by-one which will then be looped through as work intervals.
 - [x] It should be possible to use the app as a Pomodoro timer without naming
       any tasks.
 - [ ] Allow setting default intervals in a configuration file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,8 @@ fn main() {
 }
 
 pub fn switch_interval(interval_message: &str, duration: u64) -> Result<(), String> {
-    let message = &format!("{} for {} minutes", interval_message, duration);
+    let body = &format!("{} for {} minutes", interval_message, duration);
+    let summary = "Lightningfocus";
     Command::new("canberra-gtk-play")
         .arg("--id")
         .arg("complete")
@@ -27,11 +28,11 @@ pub fn switch_interval(interval_message: &str, duration: u64) -> Result<(), Stri
         .spawn()
         .map_err(|e| format!("Couldn't play notification sound: {e}"))?;
 
-    let notification = libnotify::Notification::new(message, None, None);
+    let notification = libnotify::Notification::new(summary, Some(body.as_ref()), None);
     notification
         .show()
         .map_err(|e| format!("Failed to show notification: {e}"))?;
-    println!("{message}");
+    println!("{body}");
     thread::sleep(Duration::from_secs(MINUTE * duration));
     Ok(())
 }


### PR DESCRIPTION
- Improve notification message and related var names
- Prompt user to name tasks when starting
